### PR TITLE
map page and screen

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ var KISSmetrics = module.exports = integration('KISSmetrics')
   .ensure('settings.apiKey')
   .channels(['server'])
   .mapper(mapper)
+  .mapToTrack(['page', 'screen'])
   .retries(2);
 
 /**

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "extend": "^2.0.0",
     "is": "^2.1.0",
     "isodate-traverse": "^0.3.2",
-    "segmentio-integration": "^3.0.5",
+    "segmentio-integration": "^3.2.0",
     "unix-time": "^1.0.1"
   },
   "devDependencies": {

--- a/test/fixtures/page-all.json
+++ b/test/fixtures/page-all.json
@@ -1,0 +1,24 @@
+{
+  "settings": {
+    "trackAllPages": true
+  },
+  "input": {
+    "type": "page",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "properties": {
+      "name": "Home",
+      "url": "http://example.com/example"
+    },
+    "context": {}
+  },
+  "output": {
+      "_p": "user-id",
+      "_d": 1,
+      "_k": "2b93bdf937c54fc7da2b5c6015c273bf3919c273",
+      "_t": 1388534400,
+      "_n": "Loaded a Page",
+      "name": "Home",
+      "url": "http://example.com/example"
+    }
+}

--- a/test/fixtures/page-categorized.json
+++ b/test/fixtures/page-categorized.json
@@ -1,0 +1,26 @@
+{
+  "settings": {
+    "trackCategorizedPages": true
+  },
+  "input": {
+    "type": "page",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "category": "Docs",
+    "properties": {
+      "name": "Home",
+      "url": "http://example.com/example"
+    },
+    "context": {}
+  },
+  "output": {
+      "_p": "user-id",
+      "_d": 1,
+      "_k": "2b93bdf937c54fc7da2b5c6015c273bf3919c273",
+      "_t": 1388534400,
+      "_n": "Viewed Docs Page",
+      "category": "Docs",
+      "name": "Home",
+      "url": "http://example.com/example"
+    }
+}

--- a/test/fixtures/page-named.json
+++ b/test/fixtures/page-named.json
@@ -1,0 +1,24 @@
+{
+  "settings": {
+    "trackNamedPages": true
+  },
+  "input": {
+    "type": "page",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "name": "Home",
+    "properties": {
+      "url": "http://example.com/example"
+    },
+    "context": {}
+  },
+  "output": {
+      "_p": "user-id",
+      "_d": 1,
+      "_k": "2b93bdf937c54fc7da2b5c6015c273bf3919c273",
+      "_t": 1388534400,
+      "_n": "Viewed Home Page",
+      "name": "Home",
+      "url": "http://example.com/example"
+    }
+}

--- a/test/fixtures/screen-all.json
+++ b/test/fixtures/screen-all.json
@@ -1,0 +1,24 @@
+{
+  "settings": {
+    "trackAllPages": true
+  },
+  "input": {
+    "type": "screen",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "properties": {
+      "name": "Home",
+      "url": "http://example.com/example"
+    },
+    "context": {}
+  },
+  "output": {
+      "_p": "user-id",
+      "_d": 1,
+      "_k": "2b93bdf937c54fc7da2b5c6015c273bf3919c273",
+      "_t": 1388534400,
+      "_n": "Loaded a Screen",
+      "name": "Home",
+      "url": "http://example.com/example"
+    }
+}

--- a/test/fixtures/screen-categorized.json
+++ b/test/fixtures/screen-categorized.json
@@ -1,0 +1,26 @@
+{
+  "settings": {
+    "trackCategorizedPages": true
+  },
+  "input": {
+    "type": "screen",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "category": "Docs",
+    "properties": {
+      "name": "Home",
+      "url": "http://example.com/example"
+    },
+    "context": {}
+  },
+  "output": {
+      "_p": "user-id",
+      "_d": 1,
+      "_k": "2b93bdf937c54fc7da2b5c6015c273bf3919c273",
+      "_t": 1388534400,
+      "_n": "Viewed Docs Screen",
+      "category": "Docs",
+      "name": "Home",
+      "url": "http://example.com/example"
+    }
+}

--- a/test/fixtures/screen-named.json
+++ b/test/fixtures/screen-named.json
@@ -1,0 +1,24 @@
+{
+  "settings": {
+    "trackNamedPages": true
+  },
+  "input": {
+    "type": "screen",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "name": "Home",
+    "properties": {
+      "url": "http://example.com/example"
+    },
+    "context": {}
+  },
+  "output": {
+      "_p": "user-id",
+      "_d": 1,
+      "_k": "2b93bdf937c54fc7da2b5c6015c273bf3919c273",
+      "_t": 1388534400,
+      "_n": "Viewed Home Screen",
+      "name": "Home",
+      "url": "http://example.com/example"
+    }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -109,4 +109,92 @@ describe('KISSmetrics', function () {
       kissmetrics.alias(alias, done);
     });
   });
+
+  describe('.page()', function(){
+    it('should be able to track all pages', function(done){
+      var json = test.fixture('page-all');
+      test
+        .set(settings)
+        .set(json.settings)
+        .page(json.input)
+        .query(json.output)
+        .end(function(err, res){
+          if (err) return done(err);
+          assert.equal(200, res[0].status);
+          done();
+        });
+    });
+
+    it('should be able to track categorized pages', function(done){
+      var json = test.fixture('page-categorized');
+      test
+        .set(settings)
+        .set(json.settings)
+        .page(json.input)
+        .query(json.output)
+        .end(function(err, res){
+          if (err) return done(err);
+          assert.equal(200, res[0].status);
+          done();
+        });
+    });
+
+    it('should be able to track named pages', function(done){
+      var json = test.fixture('page-named');
+      test
+        .set(settings)
+        .set(json.settings)
+        .page(json.input)
+        .query(json.output)
+        .end(function(err, res){
+          if (err) return done(err);
+          assert.equal(200, res[0].status);
+          done();
+        });
+    });
+  });
+
+  describe('.screen()', function(){
+    it('should be able to track all screens', function(done){
+      var json = test.fixture('screen-all');
+      test
+        .set(settings)
+        .set(json.settings)
+        .screen(json.input)
+        .query(json.output)
+        .end(function(err, res){
+          if (err) return done(err);
+          assert.equal(200, res[0].status);
+          done();
+        });
+    });
+
+    it('should be able to track categorized screens', function(done){
+      var json = test.fixture('screen-categorized');
+      test
+        .set(settings)
+        .set(json.settings)
+        .screen(json.input)
+        .query(json.output)
+        .end(function(err, res){
+          if (err) return done(err);
+          assert.equal(200, res[0].status);
+          done();
+        });
+    });
+
+    it('should be able to track named screens', function(done){
+      var json = test.fixture('screen-named');
+      test
+        .set(settings)
+        .set(json.settings)
+        .screen(json.input)
+        .query(json.output)
+        .end(function(err, res){
+          if (err) return done(err);
+          assert.equal(200, res[0].status);
+          done();
+        });
+    });
+  });
 });


### PR DESCRIPTION
First use of the illustrious `.mapToTrack()` static method (big shout out to amir!) — this brings the server-side  integration (which is used by mobile) to parity with the a.js, which also maps page and screen.

@yields @amillet89 
