### PR TITLE
Map Group call in KissMetrics

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,6 +40,18 @@ KISSmetrics.prototype.identify = function(payload, fn){
 };
 
 /**
+ * Group.
+ *
+ * http://support.kissmetrics.com/apis/specifications.html
+ *
+ * @param {Group} group
+ * @param {Function} fn
+ * @api public
+ */
+
+KISSmetrics.prototype.group = request('/s');
+
+/**
  * Track.
  *
  * http://support.kissmetrics.com/advanced/importing-data

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -41,6 +41,28 @@ exports.identify = function(identify){
 };
 
 /**
+ * Map group.
+ *
+ * @param {Group} group
+ * @return {Object}
+ * @api private
+ */
+
+exports.group = function(group){
+  var userId = group.userId();
+  var anonymousId = group.sessionId();
+  var payload = prefix('Group', clean(group.traits()));
+  payload = extend(payload, {
+    'Group - id': group.groupId(),
+    _p: userId || anonymousId,
+    _t: toUnixTimestamp(group.timestamp()),
+    _k: this.settings.apiKey,
+    _d: 1
+  });
+  return payload;
+};
+
+/**
  * Map track.
  *
  * @param {Track} track

--- a/test/fixtures/group-basic.json
+++ b/test/fixtures/group-basic.json
@@ -1,0 +1,23 @@
+{
+  "input": {
+    "userId": "user-id",
+    "groupId": "group-id",
+    "type": "group",
+    "timestamp": "2014",
+    "traits": {
+      "name": "Initech",
+      "industry": "Technology",
+      "employees": 329
+    }
+  },
+  "output": {
+    "_p": "user-id",
+    "Group - id": "group-id",
+    "Group - name": "Initech",
+    "Group - industry": "Technology",
+    "Group - employees": 329,
+    "_k": "2b93bdf937c54fc7da2b5c6015c273bf3919c273",
+    "_t": 1388534400,
+    "_d": 1
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -78,6 +78,12 @@ describe('KISSmetrics', function () {
         test.maps('alias-basic', settings);
       });
     });
+
+    describe('group', function(){
+      it('should map basic group', function(){
+        test.maps('group-basic', settings);
+      });
+    });
   });
 
   describe('.track()', function () {
@@ -144,6 +150,13 @@ describe('KISSmetrics', function () {
     var alias = helpers.alias();
     it('should be able to alias properly', function(done){
       kissmetrics.alias(alias, done);
+    });
+  });
+
+  describe('.group()', function () {
+    var group = helpers.group();
+    it('should be able to group properly', function(done){
+      kissmetrics.group(group, done);
     });
   });
 


### PR DESCRIPTION
This will now forward group calls to KissMetrics.

See the group-basic.json for a full example, but basically we send all
group traits as a property with the `Group' prefix.
