### PR TITLE
flatten nested objects to top level

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -10,6 +10,7 @@ var map = require('lodash.map');
 var omit = require('lodash.omit');
 var toUnixTimestamp = require('unix-time');
 var traverse = require('isodate-traverse');
+var flatten = require('flat');
 
 /**
  * Map identify.
@@ -25,9 +26,9 @@ exports.identify = function(identify){
   var payload = {};
   payload.identify = clean(identify.traits());
   payload.identify = extend(payload.identify, {
+    _k: this.settings.apiKey,
     _p: userId || anonymousId,
     _t: toUnixTimestamp(identify.timestamp()),
-    _k: this.settings.apiKey,
     _d: 1
   });
   if (userId && anonymousId) {
@@ -53,7 +54,6 @@ exports.track = function(track) {
   return extend(properties, {
     _p: track.userId() || track.sessionId(),
     _t: toUnixTimestamp(track.timestamp()),
-    _k: this.settings.apiKey,
     _n: track.event(),
     _d: 1
   });
@@ -198,8 +198,12 @@ function clean(obj){
     }
 
     // json
-    ret[k] = JSON.stringify(value);
+    // must flatten including the name of the original trait/property
+    var nestedObj = {};
+    nestedObj[k] = value;
+    var flattenedObj = flatten(nestedObj);
+    ret = extend(ret, flattenedObj);
+    delete ret[k];
   }
-
   return ret;
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "batch": "^0.5.3",
     "extend": "^2.0.0",
+    "flat": "^1.6.0",
     "is": "^2.1.0",
     "isodate-traverse": "^0.3.2",
     "lodash.map": "^3.1.4",

--- a/test/fixtures/identify-clean.json
+++ b/test/fixtures/identify-clean.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "userId": "user-id",
+    "userId": "hankim",
     "type": "identify",
     "timestamp": "2014",
     "traits": {
@@ -8,17 +8,19 @@
       "lastName": "Doe",
       "null": null,
       "address": {
-        "city": "SF"
+        "home": { "city": "SF" },
+        "school": { "city": "BOS" }
       }
     }
   },
   "output": {
     "identify": {
-      "_p": "user-id",
+      "_p": "hankim",
       "firstName": "John",
       "lastName": "Doe",
-      "address": "{\"city\":\"SF\"}",
-      "id": "user-id",
+      "address.home.city": "SF",
+      "address.school.city": "BOS",
+      "id": "hankim",
       "_k": "2b93bdf937c54fc7da2b5c6015c273bf3919c273",
       "_t": 1388534400,
       "_d": 1

--- a/test/fixtures/track-clean.json
+++ b/test/fixtures/track-clean.json
@@ -1,7 +1,7 @@
 {
   "input": {
     "type": "track",
-    "userId": "user-id",
+    "userId": "hanhan",
     "event": "some event",
     "timestamp": "2014",
     "properties": {
@@ -9,7 +9,10 @@
       "some-property": true,
       "time": "2014-01-01",
       "list": [1, 2, 3],
-      "object": {}
+      "school": {
+        "middle": { "state": "RI" },
+        "college": { "state": "MA" }
+      }
     }
   },
   "output": {
@@ -18,7 +21,9 @@
     "revenue": "19.99",
     "time": 1388534400,
     "list": "1,2,3",
-    "_p": "user-id",
+    "school.middle.state": "RI",
+    "school.college.state": "MA",
+    "_p": "hanhan",
     "_t": 1388534400,
     "_k": "2b93bdf937c54fc7da2b5c6015c273bf3919c273",
     "_n": "some event",

--- a/test/index.js
+++ b/test/index.js
@@ -86,6 +86,16 @@ describe('KISSmetrics', function () {
       kissmetrics.track(track, done);
     });
 
+    it('should properly set nested objects as properties', function(done){
+      var json = test.fixture('track-clean');
+
+      test
+        .set(settings)
+        .track(json.input)
+        .query(json.output)
+        .expects(200, done);
+    });
+
     it('should prefix event properties if prefixProperties is enabled', function(){
       kissmetrics.settings.prefixProperties = true;
       var result = kissmetrics.mapper.track.call(kissmetrics, track);


### PR DESCRIPTION
Kissmetrics wants nested objects to be flattened before sending them as event properties or user traits.

This PR will have this behavior:

``` json
{
  "input": {
    "type": "track",
    "userId": "hanhan",
    "event": "some event",
    "timestamp": "2014",
    "properties": {
      "revenue": 19.99,
      "some-property": true,
      "time": "2014-01-01",
      "list": [1, 2, 3],
      "school": {
        "middle": { "state": "RI" },
        "college": { "state": "MA" }
      }
    }
  },
  "output": {
    "Billing Amount": 19.99,
    "some-property": "true",
    "revenue": "19.99",
    "time": 1388534400,
    "list": "1,2,3",
    "school.middle.state": "RI",
    "school.college.state": "MA",
    "_p": "hanhan",
    "_t": 1388534400,
    "_k": "2b93bdf937c54fc7da2b5c6015c273bf3919c273",
    "_n": "some event",
    "_d": 1
  }
}
```

@f2prateek can you review?
