### PR TITLE
Pass along context.{ip,userAgent} as _ip and _ua

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -31,12 +31,14 @@ exports.identify = function(identify){
     _t: toUnixTimestamp(identify.timestamp()),
     _d: 1
   });
+  addIPAndUserAgent(identify, payload.identify);
   if (userId && anonymousId) {
     payload.alias = {
       _k: this.settings.apiKey,
       _p: identify.userId(),
       _n: identify.sessionId()
     };
+    addIPAndUserAgent(identify, payload.alias);
   }
   return payload;
 };
@@ -60,6 +62,7 @@ exports.group = function(group){
     _k: this.settings.apiKey,
     _d: 1
   });
+  addIPAndUserAgent(group, payload);
   return payload;
 };
 
@@ -92,13 +95,15 @@ exports.track = function(track) {
 exports.page = function(page) {
   var name = 'Viewed ' + (page.name() || page.category()) + ' Page';
   var properties = prefix('Page', page.properties());
-  return extend(properties, {
+  var payload = extend(properties, {
     _p: page.userId() || page.sessionId(),
     _t: toUnixTimestamp(page.timestamp()),
     _k: this.settings.apiKey,
     _n: name,
     _d: 1
   });
+  addIPAndUserAgent(page, payload);
+  return payload;
 };
 
 /**
@@ -112,13 +117,15 @@ exports.page = function(page) {
 exports.screen = function(screen) {
   var name = 'Viewed ' + (screen.name() || screen.category()) + ' Screen';
   var properties = prefix('Screen', screen.properties());
-  return extend(properties, {
+  var payload = extend(properties, {
     _p: screen.userId() || screen.sessionId(),
     _t: toUnixTimestamp(screen.timestamp()),
     _k: this.settings.apiKey,
     _n: name,
     _d: 1
   });
+  addIPAndUserAgent(screen, payload);
+  return payload;
 };
 
 /**
@@ -144,7 +151,8 @@ exports.completedOrder = function completedOrder(track) {
       event: event,
       properties: product,
       timestamp: track.timestamp(),
-      userId: track.userId()
+      userId: track.userId(),
+      context: track.context()
     });
   });
   var mappedProducts = map(products, function(product, i) {
@@ -185,6 +193,8 @@ function createBaseTrackProperties(track, settings) {
     properties = prefix(track.event(), properties);
   }
 
+  addIPAndUserAgent(track, properties);
+
   return extend(
     properties,
     {
@@ -224,11 +234,13 @@ function prefix(event, properties){
  */
 
 exports.alias = function(alias){
-  return {
+  var payload = {
     _k: this.settings.apiKey,
     _p: alias.from(),
     _n: alias.to()
   };
+  addIPAndUserAgent(alias, payload);
+  return payload;
 };
 
 /**
@@ -274,4 +286,23 @@ function clean(obj){
     delete ret[k];
   }
   return ret;
+}
+
+/**
+ * Add _ip and _ua properties to a properties object when track.ip() and
+ * track.userAgent() are available.
+ *
+ * @param {Track} track
+ * @param {Object} obj
+ */
+
+function addIPAndUserAgent(track, obj){
+  var ip = track.ip();
+  if (ip) {
+    obj._ip = ip;
+  }
+  var userAgent = track.userAgent();
+  if (userAgent) {
+    obj._ua = userAgent;
+  }
 }

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -296,12 +296,12 @@ function clean(obj){
  * @param {Object} obj
  */
 
-function addIPAndUserAgent(track, obj){
-  var ip = track.ip();
+function addIPAndUserAgent(msg, obj){
+  var ip = msg.ip();
   if (ip) {
     obj._ip = ip;
   }
-  var userAgent = track.userAgent();
+  var userAgent = msg.userAgent();
   if (userAgent) {
     obj._ua = userAgent;
   }

--- a/test/fixtures/alias-ip-ua.json
+++ b/test/fixtures/alias-ip-ua.json
@@ -1,0 +1,19 @@
+{
+  "input": {
+    "previousId": "previous-id",
+    "type": "alias",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "context": {
+      "ip": "8.8.8.8",
+      "userAgent": "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)"
+    }
+  },
+  "output": {
+    "_k": "2b93bdf937c54fc7da2b5c6015c273bf3919c273",
+    "_p": "previous-id",
+    "_n": "user-id",
+    "_ip": "8.8.8.8",
+    "_ua": "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)"
+  }
+}

--- a/test/fixtures/group-ip-ua.json
+++ b/test/fixtures/group-ip-ua.json
@@ -1,0 +1,29 @@
+{
+  "input": {
+    "userId": "user-id",
+    "groupId": "group-id",
+    "type": "group",
+    "timestamp": "2014",
+    "traits": {
+      "name": "Initech",
+      "industry": "Technology",
+      "employees": 329
+    },
+    "context": {
+      "ip": "8.8.8.8",
+      "userAgent": "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)"
+    }
+  },
+  "output": {
+    "_p": "user-id",
+    "Group - id": "group-id",
+    "Group - name": "Initech",
+    "Group - industry": "Technology",
+    "Group - employees": 329,
+    "_k": "2b93bdf937c54fc7da2b5c6015c273bf3919c273",
+    "_t": 1388534400,
+    "_d": 1,
+    "_ip": "8.8.8.8",
+    "_ua": "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)"
+  }
+}

--- a/test/fixtures/identify-ip-ua.json
+++ b/test/fixtures/identify-ip-ua.json
@@ -1,0 +1,36 @@
+{
+  "input": {
+    "userId": "user-id",
+    "anonymousId": "anonymous-id",
+    "type": "identify",
+    "timestamp": "2014",
+    "traits": {
+      "firstName": "John",
+      "lastName": "Doe"
+    },
+    "context": {
+      "ip": "8.8.8.8",
+      "userAgent": "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)"
+    }
+  },
+  "output": {
+    "identify": {
+      "_p": "user-id",
+      "firstName": "John",
+      "lastName": "Doe",
+      "id": "user-id",
+      "_k": "2b93bdf937c54fc7da2b5c6015c273bf3919c273",
+      "_t": 1388534400,
+      "_d": 1,
+      "_ip": "8.8.8.8",
+      "_ua": "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)"
+    },
+    "alias": {
+      "_k": "2b93bdf937c54fc7da2b5c6015c273bf3919c273",
+      "_p": "user-id",
+      "_n": "anonymous-id",
+      "_ip": "8.8.8.8",
+      "_ua": "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)"
+    }
+  }
+}

--- a/test/fixtures/page-ip-ua.json
+++ b/test/fixtures/page-ip-ua.json
@@ -1,0 +1,30 @@
+{
+  "settings": {
+    "trackAllPages": true
+  },
+  "input": {
+    "type": "page",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "name": "Home",
+    "properties": {
+      "name": "Home",
+      "url": "http://example.com/example"
+    },
+    "context": {
+      "ip": "8.8.8.8",
+      "userAgent": "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)"
+    }
+  },
+  "output": {
+      "_p": "user-id",
+      "_d": 1,
+      "_k": "2b93bdf937c54fc7da2b5c6015c273bf3919c273",
+      "_t": 1388534400,
+      "_n": "Viewed Home Page",
+      "Page - name": "Home",
+      "Page - url": "http://example.com/example",
+      "_ip": "8.8.8.8",
+      "_ua": "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)"
+    }
+}

--- a/test/fixtures/screen-ip-ua.json
+++ b/test/fixtures/screen-ip-ua.json
@@ -1,0 +1,30 @@
+{
+  "settings": {
+    "trackAllPages": true
+  },
+  "input": {
+    "type": "screen",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "name": "Home",
+    "properties": {
+      "name": "Home",
+      "url": "http://example.com/example"
+    },
+    "context": {
+      "ip": "8.8.8.8",
+      "userAgent": "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)"
+    }
+  },
+  "output": {
+      "_p": "user-id",
+      "_d": 1,
+      "_k": "2b93bdf937c54fc7da2b5c6015c273bf3919c273",
+      "_t": 1388534400,
+      "_n": "Viewed Home Screen",
+      "Screen - name": "Home",
+      "Screen - url": "http://example.com/example",
+      "_ip": "8.8.8.8",
+      "_ua": "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)"
+    }
+}

--- a/test/fixtures/track-completed-order-ip-ua.json
+++ b/test/fixtures/track-completed-order-ip-ua.json
@@ -1,0 +1,74 @@
+{
+  "input": {
+    "type": "track",
+    "userId": "user-id",
+    "event": "Completed Order",
+    "timestamp": "2014",
+    "properties": {
+      "orderId": 12345,
+      "products": [
+        {
+          "sku": "sony-pulse-sku",
+          "category": "gaming",
+          "price": 199.99,
+          "name": "sony pulse",
+          "quantity": 1
+        },
+        {
+          "sku": "sony-playstation-4-sku",
+          "category": "gaming",
+          "price": 799.99,
+          "name": "sony playstation 4",
+          "quantity": 1
+        }
+      ],
+      "revenue": 999.98
+    },
+    "context": {
+      "ip": "8.8.8.8",
+      "userAgent": "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)"
+    }
+  },
+  "output": {
+    "event": {
+      "Billing Amount": 999.98,
+      "_d": 1,
+      "_k": "2b93bdf937c54fc7da2b5c6015c273bf3919c273",
+      "_n": "Completed Order",
+      "_p": "user-id",
+      "_t": 1388534400,
+      "orderId": 12345,
+      "revenue": 999.98,
+      "_ip": "8.8.8.8",
+      "_ua": "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)"
+    },
+    "products": [
+      {
+        "_d": 1,
+        "_k": "2b93bdf937c54fc7da2b5c6015c273bf3919c273",
+        "_p": "user-id",
+        "_t": 1388534400,
+        "category": "gaming",
+        "name": "sony pulse",
+        "price": 199.99,
+        "quantity": 1,
+        "sku": "sony-pulse-sku",
+        "_ip": "8.8.8.8",
+        "_ua": "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)"
+      },
+      {
+        "_d": 1,
+        "_k": "2b93bdf937c54fc7da2b5c6015c273bf3919c273",
+        "_p": "user-id",
+        "_t": 1388534401,
+        "category": "gaming",
+        "name": "sony playstation 4",
+        "price": 799.99,
+        "quantity": 1,
+        "sku": "sony-playstation-4-sku",
+        "_ip": "8.8.8.8",
+        "_ua": "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)"
+      }
+    ]
+  }
+}

--- a/test/fixtures/track-ip-ua.json
+++ b/test/fixtures/track-ip-ua.json
@@ -1,0 +1,33 @@
+{
+  "input": {
+    "type": "track",
+    "userId": "user-id",
+    "event": "some event",
+    "timestamp": "2014",
+    "properties": {
+      "revenue": 19.99,
+      "some-property": true,
+      "time": "2014-01-01",
+      "list": [1, 2, 3],
+      "object": {}
+    },
+    "context": {
+      "ip": "8.8.8.8",
+      "userAgent": "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)"
+    }
+  },
+  "output": {
+    "Billing Amount": 19.99,
+    "some-property": "true",
+    "revenue": "19.99",
+    "time": 1388534400,
+    "list": "1,2,3",
+    "_p": "user-id",
+    "_t": 1388534400,
+    "_k": "2b93bdf937c54fc7da2b5c6015c273bf3919c273",
+    "_n": "some event",
+    "_d": 1,
+    "_ip": "8.8.8.8",
+    "_ua": "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)"
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -49,6 +49,10 @@ describe('KISSmetrics', function () {
       it('should clean and stringify objects', function(){
         test.maps('identify-clean', settings);
       });
+
+      it('should pass along IP and userAgent', function(){
+        test.maps('identify-ip-ua', settings);
+      });
     });
 
     describe('track', function(){
@@ -64,6 +68,10 @@ describe('KISSmetrics', function () {
         settings.prefixProperties = true;
         test.maps('track-prefix', settings);
       });
+
+      it('should pass along IP and userAgent', function(){
+        test.maps('track-ip-ua', settings);
+      });
     });
 
     describe('completedOrder', function() {
@@ -75,17 +83,41 @@ describe('KISSmetrics', function () {
         settings.prefixProperties = true;
         test.maps('track-completed-order-prefixed', settings);
       });
+
+      it('should pass along IP and userAgent', function(){
+        test.maps('track-completed-order-ip-ua', settings);
+      });
     });
 
     describe('alias', function(){
       it('should map basic alias', function(){
         test.maps('alias-basic', settings);
       });
+
+      it('should pass along IP and userAgent', function(){
+        test.maps('alias-ip-ua', settings);
+      });
     });
 
     describe('group', function(){
       it('should map basic group', function(){
         test.maps('group-basic', settings);
+      });
+
+      it('should pass along IP and userAgent', function(){
+        test.maps('group-ip-ua', settings);
+      });
+    });
+
+    describe('screen', function(){
+      it('should pass along IP and userAgent', function(){
+        test.maps('screen-ip-ua', settings);
+      });
+    });
+
+    describe('page', function(){
+      it('should pass along IP and userAgent', function(){
+        test.maps('page-ip-ua', settings);
       });
     });
   });


### PR DESCRIPTION
This is a reboot of #14, #19 and #20.

Our backend has been upgraded, so we now unconditionally pass along IP address and user agent with each request if they're available on the `context` object.

cc @salomon @NathanielWroblewski @percyhanna
