### PR TITLE
update ecommerce syntax from v1 to v2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -85,7 +85,7 @@ KISSmetrics.prototype.track = handler('/e');
 KISSmetrics.prototype.screen = KISSmetrics.prototype.page = handler('/e');
 
 /**
- * Completed Order.
+ * Order Completed.
  *
  * http://support.kissmetrics.com/apis/specifications.html
  *
@@ -94,9 +94,10 @@ KISSmetrics.prototype.screen = KISSmetrics.prototype.page = handler('/e');
  * @param {Object} settings
  * @param {Function} done
  */
-KISSmetrics.prototype.completedOrder = function(track, done){
+
+KISSmetrics.prototype.orderCompleted = function(track, done) {
   var self = this;
-  var payloads = mapper.completedOrder.call(this, track);
+  var payloads = mapper.orderCompleted.call(this, track);
 
   return this._request('/e', payloads.event, function(err, responses){
     if (err) {

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -129,13 +129,13 @@ exports.screen = function(screen) {
 };
 
 /**
- * Map Completed Order.
+ * Map Order Completed.
  *
  * @api private
  * @param {Track} track
  * @return {Object}
  */
-exports.completedOrder = function completedOrder(track) {
+exports.orderCompleted = function orderCompleted(track) {
   var event = track.event();
   var settings = this.settings;
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "merge-util": "^0.1.0",
     "mocha": "2.x",
     "ms": "0.x",
-    "segmentio-integration-tester": "1.x",
+    "segmentio-integration-tester": "2.x",
     "should": "^4.3.0",
     "uid": "0.0.2",
     "unix-time": "1.x"

--- a/test/fixtures/track-completed-order-ip-ua.json
+++ b/test/fixtures/track-completed-order-ip-ua.json
@@ -2,7 +2,7 @@
   "input": {
     "type": "track",
     "userId": "user-id",
-    "event": "Completed Order",
+    "event": "Order Completed",
     "timestamp": "2014",
     "properties": {
       "orderId": 12345,
@@ -34,7 +34,7 @@
       "Billing Amount": 999.98,
       "_d": 1,
       "_k": "2b93bdf937c54fc7da2b5c6015c273bf3919c273",
-      "_n": "Completed Order",
+      "_n": "Order Completed",
       "_p": "user-id",
       "_t": 1388534400,
       "orderId": 12345,

--- a/test/fixtures/track-completed-order-prefixed.json
+++ b/test/fixtures/track-completed-order-prefixed.json
@@ -2,7 +2,7 @@
   "input": {
     "type": "track",
     "userId": "user-id",
-    "event": "Completed Order",
+    "event": "Order Completed",
     "timestamp": "2014",
     "properties": {
       "orderId": 12345,
@@ -30,11 +30,11 @@
       "Billing Amount": 999.98,
       "_d": 1,
       "_k": "2b93bdf937c54fc7da2b5c6015c273bf3919c273",
-      "_n": "Completed Order",
+      "_n": "Order Completed",
       "_p": "user-id",
       "_t": 1388534400,
-      "Completed Order - orderId": 12345,
-      "Completed Order - revenue": 999.98
+      "Order Completed - orderId": 12345,
+      "Order Completed - revenue": 999.98
     },
     "products": [
       {
@@ -42,22 +42,22 @@
         "_k": "2b93bdf937c54fc7da2b5c6015c273bf3919c273",
         "_p": "user-id",
         "_t": 1388534400,
-        "Completed Order - category": "gaming",
-        "Completed Order - name": "sony pulse",
-        "Completed Order - price": 199.99,
-        "Completed Order - quantity": 1,
-        "Completed Order - sku": "sony-pulse-sku"
+        "Order Completed - category": "gaming",
+        "Order Completed - name": "sony pulse",
+        "Order Completed - price": 199.99,
+        "Order Completed - quantity": 1,
+        "Order Completed - sku": "sony-pulse-sku"
       },
       {
         "_d": 1,
         "_k": "2b93bdf937c54fc7da2b5c6015c273bf3919c273",
         "_p": "user-id",
         "_t": 1388534401,
-        "Completed Order - category": "gaming",
-        "Completed Order - name": "sony playstation 4",
-        "Completed Order - price": 799.99,
-        "Completed Order - quantity": 1,
-        "Completed Order - sku": "sony-playstation-4-sku"
+        "Order Completed - category": "gaming",
+        "Order Completed - name": "sony playstation 4",
+        "Order Completed - price": 799.99,
+        "Order Completed - quantity": 1,
+        "Order Completed - sku": "sony-playstation-4-sku"
       }
     ]
   }

--- a/test/fixtures/track-completed-order.json
+++ b/test/fixtures/track-completed-order.json
@@ -2,7 +2,7 @@
   "input": {
     "type": "track",
     "userId": "user-id",
-    "event": "Completed Order",
+    "event": "Order Completed",
     "timestamp": "2014",
     "properties": {
       "orderId": 12345,
@@ -30,7 +30,7 @@
       "Billing Amount": 999.98,
       "_d": 1,
       "_k": "2b93bdf937c54fc7da2b5c6015c273bf3919c273",
-      "_n": "Completed Order",
+      "_n": "Order Completed",
       "_p": "user-id",
       "_t": 1388534400,
       "orderId": 12345,

--- a/test/index.js
+++ b/test/index.js
@@ -75,7 +75,7 @@ describe('KISSmetrics', function () {
       });
     });
 
-    describe('completedOrder', function() {
+    describe('orderCompleted', function() {
       it('should map a basic event', function() {
         test.maps('track-completed-order', settings);
       });


### PR DESCRIPTION
This PR changes the ecommerce V1 syntax Action + Object to the new V2 syntax, Object + Action.

This PR will be waiting on a few blockers, a refactor of the Analytics-Events repo to be more concise and readable as we add more events to our spec and for similar changes to be made to all other integrations currently using V1 syntax.
