### PR TITLE
Fix aliasing in identify method.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,11 +36,11 @@ var MAX_GET_PAYLOAD = 2048;
  */
 
 KISSmetrics.prototype.identify = function(payload, fn){
-  var self = this;
+  var alias = handler('/a').bind(this);
   this._request('/s', payload.identify, function(err){
     if (err) return fn(err);
     if (!payload.alias) return fn();
-    self.alias(payload.alias, fn);
+    alias(payload.alias, fn);
   });
 };
 
@@ -159,7 +159,6 @@ KISSmetrics.prototype._request = function(path, payload, fn){
 
   if (payloadStr.length > MAX_GET_PAYLOAD) {
     request = this.post(path).send(payloadStr);
-
   } else {
     // Unfortunately we can't pass a payload string to query() until the superagent
     // dependency is updated from v0.21.0 to at least v1.0.0. See:

--- a/test/index.js
+++ b/test/index.js
@@ -218,6 +218,26 @@ describe('KISSmetrics', function () {
     it('should be able to identify correctly', function(done){
       kissmetrics.identify(identify, done);
     });
+
+    it('should be able to identify and alias correctly', function(done){
+      var json = test.fixture('identify-alias');
+      test
+        .set(settings)
+        .identify(json.input)
+        .requests(2);
+
+      test
+        .request(0)
+        .query(json.output.identify)
+        .expects(200);
+
+      test
+        .request(1)
+        .query(json.output.alias)
+        .expects(200);
+
+      test.end(done);
+    });
   });
 
   describe('.alias()', function () {


### PR DESCRIPTION
The identify mapper method spits out an alias field that is formatted for the
KISSMetrics API. e.g.

```
alias = {
      _k: this.settings.apiKey,
      _p: identify.userId(),
      _n: identify.sessionId()
}
```

The identify method incorrectly calls alias with this KISSMetrics
formatted object, instead of a Segment formatted alias call.

This causes this line `_p: alias.from(),` in the alias method mapper to
fail, because it is not being passed an alias facade object.

This patch fixes the identify method so that it directly makes a request
with the output of the identify mapper rather than running it through
the alias mapper.

This bug slipped through because the fixture identify-alias was only
being tested for mapping, but not being run through the integration.
This patch adds a test case that verifies an identify call makes 2
successful requests to the KISSMetrics API.
